### PR TITLE
Fix meta data keywords issue

### DIFF
--- a/classes/template/PKPTemplateManager.inc.php
+++ b/classes/template/PKPTemplateManager.inc.php
@@ -263,7 +263,7 @@ class PKPTemplateManager extends Smarty
                 if ($currentContext) {
                     $customHeaders = $currentContext->getLocalizedData('customHeaders');
                     if (!empty($customHeaders)) {
-                        $this->addHeader('customHeaders', $customHeaders);
+                        $this->addHeader('customHeaders', '<meta name="keywords" content="' . $customHeaders) . '">';
                     }
                 }
             }


### PR DESCRIPTION
OJS header was printing the keywords tag content instead of adding it to head tag.